### PR TITLE
Fix parser to correctly return None with an unavailable class.

### DIFF
--- a/pyvt/__init__.py
+++ b/pyvt/__init__.py
@@ -70,7 +70,7 @@ class Timetable:
         if table is None:
             return None
         rows = [row for row in table.find_all('tr') if row.attrs == {}]
-        sections = [pc for pc in (self._parse_row(c) for c in rows) if pc is not None]
+        sections = [self._parse_row(c) for c in rows if self._parse_row(c) is not None]
         return None if not sections else sections
 
     def _make_request(self, request_data):

--- a/pyvt/__init__.py
+++ b/pyvt/__init__.py
@@ -70,11 +70,7 @@ class Timetable:
         if table is None:
             return None
         rows = [row for row in table.find_all('tr') if row.attrs == {}]
-        sections = []
-        for c in rows:
-            pc = self._parse_row(c)
-            if pc is not None:
-                sections.append(pc)
+        sections = [pc for pc in (self._parse_row(c) for c in rows) if pc is not None]
         return None if not sections else sections
 
     def _make_request(self, request_data):

--- a/pyvt/__init__.py
+++ b/pyvt/__init__.py
@@ -61,6 +61,8 @@ class Timetable:
 
     def _parse_row(self, row):
         entries = [entry.text.replace('\n', '').replace('-', ' ').strip() for entry in row.find_all('td')]
+        if len(entries) <= 1:
+            return None
         return Section(**dict(zip(self.data_keys, entries)))
 
     def _parse_table(self, html):

--- a/pyvt/__init__.py
+++ b/pyvt/__init__.py
@@ -70,8 +70,12 @@ class Timetable:
         if table is None:
             return None
         rows = [row for row in table.find_all('tr') if row.attrs == {}]
-        sections = [self._parse_row(c) for c in rows]
-        return sections
+        sections = []
+        for c in rows:
+            pc = self._parse_row(c)
+            if pc is not None:
+                sections.append(pc)
+        return None if not sections else sections
 
     def _make_request(self, request_data):
         r = requests.post(self.url, data=request_data)


### PR DESCRIPTION
Currently, due to a change server side, pyvt doesn't return None when an unavailable class section is queried, instead creating an invalid Section object which only consists of a 'CRN' that is actually an error message. It seems the timetable used to return a blank table, but now returns a table with an error message.

I added some checks to ensure unavailable/invalid sections return as None.